### PR TITLE
Remove incorrect file and entitlements

### DIFF
--- a/DutchSpelling/DutchSpelling.csproj
+++ b/DutchSpelling/DutchSpelling.csproj
@@ -21,9 +21,8 @@
     <ConsolePause>false</ConsolePause>
     <MtouchArch>i386</MtouchArch>
     <MtouchLink>None</MtouchLink>
-    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchDebug>true</MtouchDebug>
-    <CodesignKey>iPhone Developer: Michael James (354MN7UPEZ)</CodesignKey>
+    <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchProfiling>true</MtouchProfiling>
     <MtouchI18n>
     </MtouchI18n>
@@ -96,7 +95,6 @@
   </ItemGroup>
   <ItemGroup>
     <BundleResource Include="Resources\Default-568h%402x.png" />
-    <BundleResource Include="Resources\vocabulary\.DS_Store" />
     <BundleResource Include="Resources\vocabulary\Animals.xml" />
     <BundleResource Include="Resources\vocabulary\Careers.xml" />
     <BundleResource Include="Resources\vocabulary\Clothes.xml" />
@@ -124,7 +122,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />
-    <None Include="Entitlements.plist" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Main.cs" />

--- a/DutchSpelling/Entitlements.plist
+++ b/DutchSpelling/Entitlements.plist
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-</dict>
-</plist>


### PR DESCRIPTION
See this forum discussion for reason why entitlements.plist triggers the
need for a provisioning profile:

https://forums.xamarin.com/discussion/comment/100088#Comment_100088

Since no entitlements are being used, there's no need to have an
entitlements.plist, and then developers can run the app on their
simulators without having a provisioning profile.

Also remove .DS_Store
