### PR TITLE
A couple of translation errors or small improvements

### DIFF
--- a/DutchSpelling/Resources/vocabulary/Animals.xml
+++ b/DutchSpelling/Resources/vocabulary/Animals.xml
@@ -6,7 +6,7 @@
   </Word>
   <Word>
     <Native>bee</Native>
-    <Target>honingbij</Target>
+    <Target>bij</Target>
   </Word>
   <Word>
     <Native>ape</Native>
@@ -14,7 +14,7 @@
   </Word>
   <Word>
     <Native>bear</Native>
-    <Target>bear</Target>
+    <Target>beer</Target>
   </Word>
   <Word>
     <Native>baboon</Native>
@@ -53,8 +53,8 @@
     <Target>haan</Target>
   </Word>
   <Word>
-    <Native>chipmunch</Native>
-    <Target>chipmunch</Target>
+    <Native>chipmunk</Native>
+    <Target>wangzakeekhoorn</Target>
   </Word>
   <Word>
     <Native>cobra</Native>
@@ -70,7 +70,7 @@
   </Word>
   <Word>
     <Native>dinosaur</Native>
-    <Target>dinosaur</Target>
+    <Target>dinosaurus</Target>
   </Word>
   <Word>
     <Native>dog</Native>
@@ -110,7 +110,7 @@
   </Word>
   <Word>
     <Native>giraffe</Native>
-    <Target>giraffe</Target>
+    <Target>giraf</Target>
   </Word>
   <Word>
     <Native>goat</Native>
@@ -126,11 +126,11 @@
   </Word>
   <Word>
     <Native>hen</Native>
-    <Target>kip</Target>
+    <Target>hen</Target>
   </Word>
   <Word>
     <Native>hog</Native>
-    <Target>varken</Target>
+    <Target>zwijn</Target>
   </Word>
   <Word>
     <Native>hornet</Native>
@@ -194,7 +194,7 @@
   </Word>
   <Word>
     <Native>sheep</Native>
-    <Target>schapen</Target>
+    <Target>schaap</Target>
   </Word>
   <Word>
     <Native>skunk</Native>
@@ -218,7 +218,7 @@
   </Word>
   <Word>
     <Native>turkey</Native>
-    <Target>turkije</Target>
+    <Target>kalkoen</Target>
   </Word>
   <Word>
     <Native>turtle</Native>


### PR DESCRIPTION
- bee: is just 'bij', honingbij would be honeybee
- bear: beer
- chipmunk: is chipmunch a typo or am I wrong here? If so ignore. Wangzakeekhoorn is the correct translation.
- dinosaur: dinosaurus
- giraffe: giraf
- hen: the female chicken is also called hen in Dutch, kip is just general name for chicken.
- hog: zwijn, varken is a pig
- sheep: as everything is written in singolar, I changed this to singolar as well. Schapen would be the plural.
- turkey: the animal is kalkoen. Turkije would be the country, that is the same in English as the animal.
